### PR TITLE
Restrict to odd primes, per Fermat

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,9 @@ We might also need to create a prime tester to roll in because we're only intere
 
 Prime number tester done, and restricted to primes of form 4k+1.
 Next need, to implement some logic to test the summation.
+
+I think that's done. 
+
+Next, restrict primes to odd primes only, per Fermat's theorem on Sums of Two Squares.
+
+

--- a/prime_4k_1_test.py
+++ b/prime_4k_1_test.py
@@ -5,7 +5,7 @@ def prime_test_func(x):
     factors = []
     
     for i in range(2, int(x**(1/2))+1):
-        if x%i == 0 & (x-1)%4 == 0:
+        if x%i == 0 & (x-1)%4 == 0 & x>2:
             factors.append(i)
             
     y = len(factors)


### PR DESCRIPTION
Additional logic to restrict prime values to >2 only, aka odd primes.